### PR TITLE
Add two additional SATA disks to CoreOS VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,6 +68,17 @@ Vagrant.configure("2") do |config|
     # in CoreOS, so tell Vagrant that so it can be smarter.
     v.check_guest_additions = false
     v.functional_vboxsf     = false
+
+    unless File.exist?("additional_disk_1st.vdi")
+      v.customize ["createhd",  "--filename", "additional_disk_1st", "--size", "2048"]
+      v.customize ["storagectl", :id, "--name", "SATA Controller", "--add", "sata"]
+    end
+    v.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", "2", "--type", "hdd", "--medium", "additional_disk_1st.vdi"]
+
+    unless File.exist?("additional_disk_2nd.vdi")
+      v.customize ["createhd",  "--filename", "additional_disk_2nd", "--size", "2048"]
+    end
+    v.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", "3", "--type", "hdd", "--medium", "additional_disk_2nd.vdi"]
   end
 
   # plugin conflict


### PR DESCRIPTION
按照青松的建议，参照了
- https://gitlab.msu.edu/gmason/vagrant-zfs/blob/master/Vagrantfile ，和
- https://github.com/mitchellh/vagrant/issues/4015#issuecomment-131440075

我尝试了，vagrant reload 没问题。

vagrant ssh 之后，用lsblk检查，能看到增加了 sda 和 sdb：

```
core@core-01 ~ $ lsblk
NAME    MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINT
sda       8:0    0    2G  0 disk  
sdb       8:16   0    2G  0 disk  
sdc       8:32   0 18.5G  0 disk  
|-sdc1    8:33   0  128M  0 part  /boot
|-sdc2    8:34   0    2M  0 part  
|-sdc3    8:35   0    1G  0 part  
| `-usr 254:0    0 1016M  1 crypt /usr
|-sdc4    8:36   0    1G  0 part  
|-sdc6    8:38   0  128M  0 part  /usr/share/oem
|-sdc7    8:39   0   64M  0 part  
`-sdc9    8:41   0 16.1G  0 part  /
```
